### PR TITLE
CODEOWNERS: use correct location

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
-
-/crates/avalanche-types/ @gyuho
-/crates/avalanche-consensus/ @gyuho
-/crates/avalanche-types/proto/ @hexfusion @gyuho
-/crates/avalanche-types/subnet/ @hexfusion @gyuho
+* @exdx @gyuho @hexfusion @richardpringle

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
 * @exdx @gyuho @hexfusion @richardpringle

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @exdx @gyuho @hexfusion @richardpringle


### PR DESCRIPTION
the canonical source of truth has been .github/CODEOWNERS