### PR TITLE
docs/release 2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,16 @@ jobs:
           toolchain: stable
           override: true
       - name: publish avalanche-types crate
+        continue-on-error: true
+        shell: bash
         run: |
+          ./scripts/check_crate_version.sh avalanche-types
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p avalanche-types
       - name: publish avalanche-consensus crate
+        continue-on-error: true
+        shell: bash
         run: |
+          ./scripts/check_crate_version.sh avalanche-consensus
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p avalanche-consensus

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ avalanche-rs provides a wide set of modules to use as imports in other projects.
 ### Enable Rust Developers to Build VMs
 The Rust SDK in [subnet](./crates/avalanche-types/src/subnet/) provides tools to build Rust VMs on Avalanche.
 
+## Releasing New Versions
+To release a new version, first be sure to increment the version in the `Cargo.toml` file for one or both of `avalanche-types` and `avalanche-consensus` to the new version. It's not possible to republish an existing version of a crate on crates.io. The other crates in this project are not published and do not need to be updated. CI will skip publishing the crate if the current and remote versions are found to be the same.
+
+Once the version is incremented, simply push a semver tag (for example v0.1.0) to the main branch. The CI automation will generate a draft release. Once that released is published CI will automatically push the latest versions of the crates to crates.io. 
+
 ## License 
 avalanche-rs is licensed under the [Ecosystem License](./LICENSE).
 

--- a/scripts/check_crate_version.sh
+++ b/scripts/check_crate_version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+CRATE=$1
+if [[ $CRATE == "avalanche-types" ]]; then
+	echo "Checking avalanche-types"
+
+	avalanche_types_published_version=$(cargo search avalanche-types | head -1 | cut -d'"' -f 2)
+	echo $avalanche_types_published_version
+
+	avalanche_types_current_version=$(cargo pkgid -p avalanche-types | cut -d "#" -f2)
+	echo $avalanche_types_current_version
+
+	if [ $avalanche_types_published_version = $avalanche_types_current_version ]; then
+		echo "The current and published versions are equal."
+        exit 1
+	else
+		echo "The current and published versions are different."
+        exit 0
+	fi
+
+elif [[ $CRATE == "avalanche-consensus" ]]; then
+	echo "Checking avalanche-consensus"
+
+	avalanche_consensus_published_version=$(cargo search avalanche-consensus | head -1 | cut -d'"' -f 2)
+	echo $avalanche_consensus_published_version
+
+	avalanche_consensus_current_version=$(cargo pkgid -p avalanche-consensus | cut -d "#" -f2)
+	echo $avalanche_consensus_current_version
+
+	if [ $avalanche_consensus_published_version = $avalanche_consensus_current_version ]; then
+		echo "The current and published versions are equal."
+        exit 1
+	else
+		echo "The current and published versions are different."
+        exit 0
+	fi
+
+else
+	echo "Invalid crate name"
+    exit 1
+fi


### PR DESCRIPTION
This is #31, just checking if the branch protections rules come into effect differently on a new PR 
- ci: Add crate version check
- CODEOWNERS: use correct location (#37)
