### PR TITLE
ci: Overhaul release to use crate names as tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,24 +6,28 @@ on:
     types: [published]
 
 jobs:
-  publish-avalanche-rs-crate:
-    name: avalanche-rs-lib
+  publish-avalanche-types-crate:
+    name: publish-avalanche-types
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.release.tag_name, 'v')"
+    if: "startsWith(github.event.release.tag_name, 'avalanche-types-v')"
     steps:
       - uses: actions/checkout@v1
       - uses: dtolnay/rust-toolchain@stable
       - name: publish avalanche-types crate
-        continue-on-error: true
         shell: bash
         run: |
-          ./scripts/check_crate_version.sh avalanche-types
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p avalanche-types
+  publish-avalanche-consensus-crate:
+    name: publish-avalanche-consensus
+    runs-on: ubuntu-latest
+    if: "startsWith(github.event.release.tag_name, 'avalanche-consensus-v')"
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@stable
       - name: publish avalanche-consensus crate
-        continue-on-error: true
         shell: bash
         run: |
-          ./scripts/check_crate_version.sh avalanche-consensus
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p avalanche-consensus
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "avalanche-types-v*.*.*"
+      - "avalanche-consensus-v*.*.*"
 
 jobs:
   build:


### PR DESCRIPTION
Allows publishing crates based on the name in the tag.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
