### PR TITLE
*: v0.1.3

### DIFF
--- a/crates/avalanche-types/Cargo.toml
+++ b/crates/avalanche-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-types"
-version = "0.1.2" # https://crates.io/crates/avalanche-types
+version = "0.1.3" # https://crates.io/crates/avalanche-types
 edition = "2021"
 rust-version = "1.70" # use "rustup override set stable" to overwrite current toolchain
 publish = true


### PR DESCRIPTION
Releases a new version to incorporate rpcchainvm changes.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
