### PR TITLE
Fixing clippy warnings

### DIFF
--- a/crates/avalanche-types/examples/evm_contract_counter_increment.rs
+++ b/crates/avalanche-types/examples/evm_contract_counter_increment.rs
@@ -5,7 +5,7 @@ use std::{env::args, io, str::FromStr};
 use avalanche_types::{evm::abi, jsonrpc::client::evm as json_client_evm, key, wallet};
 use ethers_core::{
     abi::{Function, StateMutability},
-    types::{H160, U256},
+    types::H160,
 };
 
 /// cargo run --example evm_contract_counter_increment --features="jsonrpc_client evm" -- [HTTP RPC ENDPOINT] [PRIVATE KEY] [CONTRACT ADDRESS]

--- a/crates/avalanche-types/examples/evm_contract_counter_increment_append_calldata.rs
+++ b/crates/avalanche-types/examples/evm_contract_counter_increment_append_calldata.rs
@@ -7,7 +7,7 @@ use avalanche_types::{
 };
 use ethers_core::{
     abi::{encode as abi_encode, Function, StateMutability, Token},
-    types::{H160, U256},
+    types::H160,
 };
 
 /// cargo run --example evm_contract_counter_increment_append_calldata --features="jsonrpc_client evm" -- [HTTP RPC ENDPOINT] [PRIVATE KEY] [FORWARDER CONTRACT ADDRESS] [RECIPIENT CONTRACT ADDRESS]

--- a/crates/avalanche-types/examples/evm_contract_counter_increment_forwarder_proxy_call.rs
+++ b/crates/avalanche-types/examples/evm_contract_counter_increment_forwarder_proxy_call.rs
@@ -5,7 +5,7 @@ use std::{env::args, io, str::FromStr};
 use avalanche_types::{evm::abi, jsonrpc::client::evm as json_client_evm, key, wallet};
 use ethers_core::{
     abi::{Function, Param, ParamType, StateMutability, Token},
-    types::{H160, U256},
+    types::H160,
 };
 
 /// cargo run --example evm_contract_counter_increment_forwarder_proxy_call --features="jsonrpc_client evm" -- [HTTP RPC ENDPOINT] [PRIVATE KEY] [FORWARDER CONTRACT ADDRESS] [RECIPIENT CONTRACT ADDRESS]

--- a/crates/avalanche-types/examples/evm_contract_simple_registry_register.rs
+++ b/crates/avalanche-types/examples/evm_contract_simple_registry_register.rs
@@ -5,7 +5,7 @@ use std::{env::args, io, str::FromStr};
 use avalanche_types::{evm::abi, jsonrpc::client::evm as json_client_evm, key, wallet};
 use ethers_core::{
     abi::{Function, Param, ParamType, StateMutability, Token},
-    types::{H160, U256},
+    types::H160,
 };
 
 /// cargo run --example evm_contract_simple_registry_register --features="jsonrpc_client evm" -- [HTTP RPC ENDPOINT] [PRIVATE KEY] [CONTRACT ADDRESS]

--- a/crates/avalanche-types/src/avalanchego/config.rs
+++ b/crates/avalanche-types/src/avalanchego/config.rs
@@ -350,15 +350,11 @@ pub const DEFAULT_PROCESS_CONTEXT_FILE: &str = "/data/process.json";
 
 impl Default for Config {
     fn default() -> Self {
-        Self::default()
+        Self::default_main()
     }
 }
 
 impl Config {
-    pub fn default() -> Self {
-        Self::default_main()
-    }
-
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
     pub fn default_main() -> Self {

--- a/crates/avalanche-types/src/avalanchego/genesis.rs
+++ b/crates/avalanche-types/src/avalanchego/genesis.rs
@@ -93,12 +93,6 @@ pub const DEFAULT_INITIAL_STAKE_DURATION_OFFSET: u64 = 5400; // 1.5 hour
 
 impl Default for Genesis {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Genesis {
-    pub fn default() -> Self {
         let now_unix = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("unexpected None duration_since")
@@ -119,7 +113,9 @@ impl Genesis {
             message: Some(String::new()),
         }
     }
+}
 
+impl Genesis {
     /// Creates a new Genesis object with "keys" number of generated pre-funded keys.
     pub fn new<T: key::secp256k1::ReadOnly>(network_id: u32, seed_keys: &[T]) -> io::Result<Self> {
         // maximize total supply
@@ -146,8 +142,10 @@ impl Genesis {
         log::info!("allocate {} for each key in C-chain", c_alloc_per_key);
 
         // allocation for C-chain
-        let mut default_c_alloc = coreth_genesis::AllocAccount::default();
-        default_c_alloc.balance = primitive_types::U256::from(c_alloc_per_key);
+        let default_c_alloc = coreth_genesis::AllocAccount {
+            balance: primitive_types::U256::from(c_alloc_per_key),
+            ..Default::default()
+        };
 
         // "initial_staked_funds" addresses use all P-chain balance
         // so keep the remaining balance for other keys than "last" key
@@ -160,14 +158,15 @@ impl Genesis {
 
         for k in seed_keys.iter() {
             // allocation for X/P-chain
-            let mut xp_alloc = Allocation::default();
-            xp_alloc.eth_addr = Some(k.eth_address());
-            xp_alloc.avax_addr = Some(k.hrp_address(network_id, "X").unwrap());
-            xp_alloc.initial_amount = Some(xp_alloc_per_key);
-            xp_alloc.unlock_schedule = Some(vec![LockedAmount {
-                amount: Some(xp_alloc_per_key),
-                ..Default::default()
-            }]);
+            let xp_alloc = Allocation {
+                eth_addr: Some(k.eth_address()),
+                avax_addr: Some(k.hrp_address(network_id, "X").unwrap()),
+                initial_amount: Some(xp_alloc_per_key),
+                unlock_schedule: Some(vec![LockedAmount {
+                    amount: Some(xp_alloc_per_key),
+                    ..Default::default()
+                }])
+            };
             xp_allocs.push(xp_alloc);
 
             c_allocs.insert(
@@ -178,8 +177,10 @@ impl Genesis {
 
         // make sure to use different network ID than "local" network ID
         // ref. https://github.com/ava-labs/avalanche-ops/issues/8
-        let mut c_chain_genesis = coreth_genesis::Genesis::default();
-        c_chain_genesis.alloc = Some(c_allocs);
+        let c_chain_genesis = coreth_genesis::Genesis{
+            alloc: Some(c_allocs),
+            ..Default::default()
+        };
 
         Ok(Self {
             network_id,
@@ -305,12 +306,6 @@ pub const DEFAULT_LOCKED_AMOUNT_P_CHAIN: u64 = 200000000000000000;
 
 impl Default for Allocation {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Allocation {
-    pub fn default() -> Self {
         let unlock_empty = LockedAmount::default();
         Self {
             avax_addr: None,
@@ -339,12 +334,6 @@ pub struct LockedAmount {
 
 impl Default for LockedAmount {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl LockedAmount {
-    pub fn default() -> Self {
         // NOTE: to place lock-time, use this:
         // let now_unix = SystemTime::now()
         //     .duration_since(SystemTime::UNIX_EPOCH)
@@ -374,12 +363,6 @@ pub const DEFAULT_DELEGATION_FEE: u32 = 62500;
 
 impl Default for Staker {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Staker {
-    pub fn default() -> Self {
         Self {
             node_id: None,
             reward_address: None,

--- a/crates/avalanche-types/src/coreth/chain_config.rs
+++ b/crates/avalanche-types/src/coreth/chain_config.rs
@@ -158,15 +158,9 @@ pub const DEFAULT_LOG_JSON_FORMAT: bool = true;
 pub const DEFAULT_OFFLINE_PRUNING_DATA_DIR: &str = "/data/c-chain-offline-pruning";
 
 impl Default for Config {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Config {
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             snowman_api_enabled: None,
             coreth_admin_api_enabled: Some(DEFAULT_CORETH_ADMIN_API_ENABLED),
@@ -254,7 +248,9 @@ impl Config {
             tx_lookup_limit: None,
         }
     }
+}
 
+impl Config {
     pub fn encode_json(&self) -> io::Result<String> {
         serde_json::to_string(&self)
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed to serialize JSON {}", e)))

--- a/crates/avalanche-types/src/coreth/genesis.rs
+++ b/crates/avalanche-types/src/coreth/genesis.rs
@@ -63,12 +63,6 @@ pub const DEFAULT_INITIAL_AMOUNT: &str = "0x204FCE5E3E25026110000000";
 
 impl Default for Genesis {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Genesis {
-    pub fn default() -> Self {
         let mut alloc = BTreeMap::new();
         alloc.insert(
             // ref. <https://github.com/ava-labs/coreth/blob/v0.11.5/params/config.go>
@@ -98,7 +92,9 @@ impl Genesis {
             base_fee: None,
         }
     }
+}
 
+impl Genesis {
     pub fn encode_json(&self) -> io::Result<String> {
         serde_json::to_string(&self)
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed to serialize JSON {}", e)))
@@ -185,12 +181,6 @@ pub struct ChainConfig {
 
 impl Default for ChainConfig {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl ChainConfig {
-    pub fn default() -> Self {
         Self {
             // don't use local ID "43112" to avoid config override
             // ref. <https://github.com/ava-labs/coreth/blob/v0.8.6/plugin/evm/vm.go#L326-L328>
@@ -252,12 +242,6 @@ pub struct AllocAccount {
 
 impl Default for AllocAccount {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl AllocAccount {
-    pub fn default() -> Self {
         Self {
             code: None,
             storage: None,

--- a/crates/avalanche-types/src/evm/eip1559/mod.rs
+++ b/crates/avalanche-types/src/evm/eip1559/mod.rs
@@ -150,6 +150,12 @@ impl Transaction {
     }
 }
 
+impl Default for Transaction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Decodes the RLP-encoded signed "ethers_core::types::transaction::eip2718::TypedTransaction" bytes.
 /// ref. <https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_sendrawtransaction>
 pub fn decode_signed_rlp(b: impl AsRef<[u8]>) -> io::Result<(TypedTransaction, Signature)> {

--- a/crates/avalanche-types/src/evm/eip712/gsn/mod.rs
+++ b/crates/avalanche-types/src/evm/eip712/gsn/mod.rs
@@ -414,6 +414,12 @@ impl Tx {
     }
 }
 
+impl Default for Tx {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Implements "type_hash".
 /// ref. "ethers_core::types::transaction::eip712::EIP712_DOMAIN_TYPE_HASH"
 /// ref. <https://github.com/opengsn/gsn/blob/master/packages/contracts/src/forwarder/Forwarder.sol> "registerRequestType"

--- a/crates/avalanche-types/src/subnet/config/consensus.rs
+++ b/crates/avalanche-types/src/subnet/config/consensus.rs
@@ -31,15 +31,9 @@ pub struct SnowballParameters {
 }
 
 impl Default for SnowballParameters {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl SnowballParameters {
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             k: 20,
             alpha: 15,
@@ -66,15 +60,9 @@ pub struct Parameters {
 }
 
 impl Default for Parameters {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Parameters {
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             snowball_parameters: SnowballParameters::default(),
             parents: 5,

--- a/crates/avalanche-types/src/subnet/config/gossip.rs
+++ b/crates/avalanche-types/src/subnet/config/gossip.rs
@@ -15,15 +15,9 @@ pub struct SenderConfig {
 }
 
 impl Default for SenderConfig {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl SenderConfig {
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             gossip_accepted_frontier_validator_size: 0,
             gossip_accepted_frontier_non_validator_size: 0,

--- a/crates/avalanche-types/src/subnet/config/mod.rs
+++ b/crates/avalanche-types/src/subnet/config/mod.rs
@@ -33,15 +33,9 @@ pub struct Config {
 }
 
 impl Default for Config {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Config {
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             gossip_sender_config: gossip::SenderConfig::default(),
             validator_only: false,
@@ -49,7 +43,9 @@ impl Config {
             proposer_min_block_delay: 1000 * 1000 * 1000, // 1-second
         }
     }
+}
 
+impl Config {
     pub fn encode_json(&self) -> io::Result<String> {
         serde_json::to_string(&self)
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed to serialize JSON {}", e)))

--- a/crates/avalanche-types/src/subnet/rpc/snow/engine/common/appsender/client.rs
+++ b/crates/avalanche-types/src/subnet/rpc/snow/engine/common/appsender/client.rs
@@ -45,7 +45,6 @@ impl super::AppSender for AppSenderClient {
 
         let mut id_bytes: Vec<Bytes> = Vec::with_capacity(node_ids.len());
         for node_id in node_ids.iter() {
-            let node_id = node_id;
             id_bytes.push(Bytes::from(node_id.to_vec()))
         }
 

--- a/crates/avalanche-types/src/subnet_evm/chain_config.rs
+++ b/crates/avalanche-types/src/subnet_evm/chain_config.rs
@@ -197,15 +197,9 @@ pub const DEFAULT_LOG_LEVEL: &str = "info";
 pub const DEFAULT_LOG_JSON_FORMAT: bool = true;
 
 impl Default for Config {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Config {
     /// The defaults do not match with the ones in avalanchego,
     /// as this is for avalanche-ops based deployments.
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             snowman_api_enabled: None,
             admin_api_enabled: Some(DEFAULT_ADMIN_API_ENABLED),
@@ -314,7 +308,9 @@ impl Config {
             accepted_cache_size: Some(32),
         }
     }
+}
 
+impl Config {
     pub fn encode_json(&self) -> io::Result<String> {
         serde_json::to_string(&self)
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed to serialize JSON {}", e)))

--- a/crates/avalanche-types/src/subnet_evm/genesis.rs
+++ b/crates/avalanche-types/src/subnet_evm/genesis.rs
@@ -70,12 +70,6 @@ pub const DEFAULT_INITIAL_AMOUNT: &str = "0x204FCE5E3E25026110000000";
 
 impl Default for Genesis {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Genesis {
-    pub fn default() -> Self {
         let mut alloc = BTreeMap::new();
         alloc.insert(
             // ref. https://github.com/ava-labs/subnet-evm/blob/master/networks/11111/genesis.json
@@ -112,7 +106,9 @@ impl Genesis {
             base_fee: None,
         }
     }
+}
 
+impl Genesis {
     /// Creates a new Genesis object with "keys" number of generated pre-funded keys.
     pub fn new(seed_eth_addrs: Vec<String>) -> io::Result<Self> {
         // maximize total supply
@@ -126,8 +122,10 @@ impl Genesis {
         // divide by 2, allow more room for transfers
         let alloc_per_key = alloc_per_key / 2;
 
-        let mut default_alloc = AllocAccount::default();
-        default_alloc.balance = primitive_types::U256::from(alloc_per_key);
+        let default_alloc = AllocAccount {
+            balance: primitive_types::U256::from(alloc_per_key),
+            ..Default::default()
+        };
 
         let mut allocs = BTreeMap::new();
         for eth_addr in seed_eth_addrs.iter() {
@@ -137,8 +135,10 @@ impl Genesis {
             );
         }
 
-        let mut subnet_evm_genesis = Self::default();
-        subnet_evm_genesis.alloc = Some(allocs);
+        let subnet_evm_genesis = Self {
+            alloc: Some(allocs),
+            ..Self::default()
+        };
 
         Ok(subnet_evm_genesis)
     }
@@ -229,14 +229,8 @@ pub struct ChainConfig {
 }
 
 impl Default for ChainConfig {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl ChainConfig {
     /// ref. <https://pkg.go.dev/github.com/ava-labs/subnet-evm/params#pkg-variables>
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             // don't use local ID "43112" to avoid config override
             // ref. <https://github.com/ava-labs/coreth/blob/v0.8.6/plugin/evm/vm.go#L326-L328>
@@ -307,18 +301,12 @@ pub struct FeeConfig {
 }
 
 impl Default for FeeConfig {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl FeeConfig {
     /// ref. <https://github.com/ava-labs/public-chain-assets/blob/main/chains/53935/genesis.json>
     /// ref. <https://pkg.go.dev/github.com/ava-labs/subnet-evm/params#pkg-variables>
     /// ref. <https://github.com/ava-labs/subnet-evm/blob/master/scripts/run.sh>
     /// ref. <https://www.rapidtables.com/convert/number/decimal-to-hex.html>
     /// ref. <https://www.rapidtables.com/convert/number/hex-to-decimal.html>
-    pub fn default() -> Self {
+    fn default() -> Self {
         Self {
             // ref. <https://github.com/ava-labs/subnet-evm/blob/master/scripts/run.sh>
             gas_limit: Some(20_000_000),
@@ -354,12 +342,6 @@ pub struct ContractDeployerAllowListConfig {
 
 impl Default for ContractDeployerAllowListConfig {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl ContractDeployerAllowListConfig {
-    pub fn default() -> Self {
         Self {
             allow_list_admins: None,
             block_timestamp: Some(0),
@@ -388,12 +370,6 @@ pub struct ContractNativeMinterConfig {
 
 impl Default for ContractNativeMinterConfig {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl ContractNativeMinterConfig {
-    pub fn default() -> Self {
         Self {
             allow_list_admins: None,
             block_timestamp: Some(0),
@@ -421,12 +397,6 @@ pub struct TxAllowListConfig {
 
 impl Default for TxAllowListConfig {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl TxAllowListConfig {
-    pub fn default() -> Self {
         Self {
             allow_list_admins: None,
             block_timestamp: Some(0),
@@ -454,12 +424,6 @@ pub struct FeeManagerConfig {
 
 impl Default for FeeManagerConfig {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl FeeManagerConfig {
-    pub fn default() -> Self {
         Self {
             allow_list_admins: None,
             block_timestamp: Some(0),
@@ -490,12 +454,6 @@ pub struct AllocAccount {
 
 impl Default for AllocAccount {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl AllocAccount {
-    pub fn default() -> Self {
         Self {
             code: None,
             storage: None,

--- a/crates/avalanche-types/src/xsvm/genesis.rs
+++ b/crates/avalanche-types/src/xsvm/genesis.rs
@@ -20,15 +20,6 @@ pub struct Genesis {
 
 impl Default for Genesis {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-pub const CODEC_VERSION: u16 = 0;
-pub const DEFAULT_INITIAL_AMOUNT: u64 = 1000000000;
-
-impl Genesis {
-    pub fn default() -> Self {
         Self {
             timestamp: 0,
             allocations: Some(vec![Allocation {
@@ -38,7 +29,12 @@ impl Genesis {
             }]),
         }
     }
+}
 
+pub const CODEC_VERSION: u16 = 0;
+pub const DEFAULT_INITIAL_AMOUNT: u64 = 1000000000;
+
+impl Genesis {
     /// Creates a new Genesis object with "keys" number of generated pre-funded keys.
     pub fn new<T: key::secp256k1::ReadOnly>(seed_keys: &[T]) -> io::Result<Self> {
         // maximize total supply
@@ -60,8 +56,10 @@ impl Genesis {
             });
         }
 
-        let mut genesis = Self::default();
-        genesis.allocations = Some(allocs);
+        let genesis = Self {
+            allocations: Some(allocs),
+            ..Self::default()
+        };
 
         Ok(genesis)
     }
@@ -130,12 +128,6 @@ pub struct Allocation {
 
 impl Default for Allocation {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Allocation {
-    pub fn default() -> Self {
         Self {
             address: short::Id::empty(),
             balance: 0,

--- a/crates/avalanche-types/tests/rpc/database/mod.rs
+++ b/crates/avalanche-types/tests/rpc/database/mod.rs
@@ -240,8 +240,7 @@ async fn test_db_manager() {
 
     let vdb = VersionedDatabase::new(DatabaseClient::new(client_conn), Version::new(0, 0, 1));
 
-    let mut databases: Vec<VersionedDatabase> = Vec::new();
-    databases.push(vdb);
+    let databases: Vec<VersionedDatabase> = vec![vdb];
 
     let manager = DatabaseManager::from_databases(databases);
     let current = manager.current().await.unwrap();


### PR DESCRIPTION
This PR fixes clippy warnings which were most easily able to be fixed. 

The primary chunk of warnings were due to a associated function `Self::default()` existing but also implementing `Default`. There should (hopefully) be no breaking changes from removing the associated function as user's code will fall back to `Default::default`.

Another clippy warning that is a potential breaking change is implementing Default on Transaction and Tx, though this is only a issue in contrived scenarios.

As for the remaining clippy warnings, only 3 remain:
- [Associated function `new` doesn't return `Self`](https://rust-lang.github.io/rust-clippy/master/index.html#new_ret_no_self) for many types
  - I am not familiar enough with the codebase to see where these functions would should be moved to
- [Function has too arguments](https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments) for [`CommonVm::initialize`](https://github.com/ava-labs/avalanche-rs/blob/87a2b4b3ac45492d681b39c99ebb16d684d8e1a3/crates/avalanche-types/src/subnet/rpc/snow/engine/common/vm.rs#L33-L42)
- [Module has the same name as its containing module](https://rust-lang.github.io/rust-clippy/master/index.html#module_inception) for [`proto/pb/message.rs`](https://github.com/ava-labs/avalanche-rs/blob/87a2b4b3ac45492d681b39c99ebb16d684d8e1a3/crates/avalanche-types/src/proto/pb/message.rs#L9)
  - Since I think this is intentional, maybe it should be turned off? Or maybe the module can be removed.