### PR TITLE
Fix (de)serialization of transferable outputs

### DIFF
--- a/crates/avalanche-types/src/avm/txs/export.rs
+++ b/crates/avalanche-types/src/avm/txs/export.rs
@@ -69,28 +69,7 @@ impl Tx {
         packer.pack_bytes(self.destination_chain_id.as_ref())?;
 
         // pack the third field in the struct
-        if self.destination_chain_transferable_outputs.is_some() {
-            let destination_chain_transferable_outputs = self
-                .destination_chain_transferable_outputs
-                .as_ref()
-                .unwrap();
-            packer.pack_u32(destination_chain_transferable_outputs.len() as u32)?;
-
-            for transferable_output in destination_chain_transferable_outputs.iter() {
-                // "TransferableOutput.Asset" is struct and serialize:"true"
-                // but embedded inline in the struct "TransferableOutput"
-                // so no need to encode type ID
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#Asset
-                packer.pack_bytes(transferable_output.asset_id.as_ref())?;
-
-                // fx_id is serialize:"false" thus skipping serialization
-
-                packer.pack(&transferable_output.out)?;
-            }
-        } else {
-            packer.pack_u32(0_u32)?;
-        }
+        packer.pack(&self.destination_chain_transferable_outputs)?;
 
         // take bytes just for hashing computation
         let tx_bytes_with_no_signature = packer.take_bytes();

--- a/crates/avalanche-types/src/avm/txs/export.rs
+++ b/crates/avalanche-types/src/avm/txs/export.rs
@@ -1,10 +1,5 @@
 //! Base export transaction type.
-use crate::{
-    avm::txs::fx,
-    codec,
-    errors::{Error, Result},
-    hash, ids, key, platformvm, txs,
-};
+use crate::{avm::txs::fx, codec, errors::Result, hash, ids, key, txs};
 use serde::{Deserialize, Serialize};
 
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/avm#Tx>
@@ -91,98 +86,7 @@ impl Tx {
 
                 // fx_id is serialize:"false" thus skipping serialization
 
-                // decide the type
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput
-                if transferable_output.transfer_output.is_none()
-                    && transferable_output.stakeable_lock_out.is_none()
-                {
-                    return Err(Error::Other {
-                        message:  "unexpected Nones in TransferableOutput transfer_output and stakeable_lock_out".to_string(),
-                        retryable: false,
-                    });
-                }
-                let type_id_transferable_out = {
-                    if transferable_output.transfer_output.is_some() {
-                        key::secp256k1::txs::transfer::Output::type_id()
-                    } else {
-                        platformvm::txs::StakeableLockOut::type_id()
-                    }
-                };
-                // marshal type ID for "key::secp256k1::txs::transfer::Output" or "platformvm::txs::StakeableLockOut"
-                packer.pack_u32(type_id_transferable_out)?;
-
-                match type_id_transferable_out {
-                    7 => {
-                        // "key::secp256k1::txs::transfer::Output"
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                        let transfer_output = transferable_output.transfer_output.clone().unwrap();
-
-                        // marshal "secp256k1fx.TransferOutput.Amt" field
-                        packer.pack_u64(transfer_output.amount)?;
-
-                        // "secp256k1fx.TransferOutput.OutputOwners" is struct and serialize:"true"
-                        // but embedded inline in the struct "TransferOutput"
-                        // so no need to encode type ID
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#OutputOwners
-                        packer.pack_u64(transfer_output.output_owners.locktime)?;
-                        packer.pack_u32(transfer_output.output_owners.threshold)?;
-                        packer.pack_u32(transfer_output.output_owners.addresses.len() as u32)?;
-                        for addr in transfer_output.output_owners.addresses.iter() {
-                            packer.pack_bytes(addr.as_ref())?;
-                        }
-                    }
-                    22 => {
-                        // "platformvm::txs::StakeableLockOut"
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut
-                        let stakeable_lock_out =
-                            transferable_output.stakeable_lock_out.clone().unwrap();
-
-                        // marshal "platformvm::txs::StakeableLockOut.locktime" field
-                        packer.pack_u64(stakeable_lock_out.locktime)?;
-
-                        // secp256k1fx.TransferOutput type ID
-                        packer.pack_u32(7)?;
-
-                        // "platformvm.StakeableLockOut.TransferOutput" is struct and serialize:"true"
-                        // but embedded inline in the struct "StakeableLockOut"
-                        // so no need to encode type ID
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#OutputOwners
-                        //
-                        // marshal "secp256k1fx.TransferOutput.Amt" field
-                        packer.pack_u64(stakeable_lock_out.transfer_output.amount)?;
-                        packer
-                            .pack_u64(stakeable_lock_out.transfer_output.output_owners.locktime)?;
-                        packer
-                            .pack_u32(stakeable_lock_out.transfer_output.output_owners.threshold)?;
-                        packer.pack_u32(
-                            stakeable_lock_out
-                                .transfer_output
-                                .output_owners
-                                .addresses
-                                .len() as u32,
-                        )?;
-                        for addr in stakeable_lock_out
-                            .transfer_output
-                            .output_owners
-                            .addresses
-                            .iter()
-                        {
-                            packer.pack_bytes(addr.as_ref())?;
-                        }
-                    }
-                    _ => {
-                        return Err(Error::Other {
-                            message: format!(
-                                "unexpected type ID {} for TransferableOutput",
-                                type_id_transferable_out
-                            ),
-                            retryable: false,
-                        });
-                    }
-                }
+                packer.pack(&transferable_output.out)?;
             }
         } else {
             packer.pack_u32(0_u32)?;

--- a/crates/avalanche-types/src/avm/txs/import.rs
+++ b/crates/avalanche-types/src/avm/txs/import.rs
@@ -128,10 +128,7 @@ impl Tx {
                         // so no need to encode type ID
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferInput
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#Input
-                        packer.pack_u32(transfer_input.sig_indices.len() as u32)?;
-                        for idx in transfer_input.sig_indices.iter() {
-                            packer.pack_u32(*idx)?;
-                        }
+                        packer.pack(&transfer_input.sig_indices)?;
                     }
                     21 => {
                         // "platformvm::txs::StakeableLockIn"
@@ -157,11 +154,7 @@ impl Tx {
                         // so no need to encode type ID
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferInput
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#Input
-                        packer
-                            .pack_u32(stakeable_lock_in.transfer_input.sig_indices.len() as u32)?;
-                        for idx in stakeable_lock_in.transfer_input.sig_indices.iter() {
-                            packer.pack_u32(*idx)?;
-                        }
+                        packer.pack(&stakeable_lock_in.transfer_input.sig_indices)?;
                     }
                     _ => {
                         return Err(Error::Other {

--- a/crates/avalanche-types/src/avm/txs/mod.rs
+++ b/crates/avalanche-types/src/avm/txs/mod.rs
@@ -4,7 +4,12 @@ pub mod fx;
 pub mod import;
 pub mod vertex;
 
-use crate::{codec, errors::Result, hash, ids, key, txs};
+use crate::{
+    codec,
+    errors::Result,
+    hash, ids, key,
+    txs::{self},
+};
 use serde::{Deserialize, Serialize};
 
 /// Base transaction.
@@ -135,7 +140,7 @@ impl Tx {
 /// ref. "avalanchego/vms/avm.TestBaseTxSerialization"
 #[test]
 fn test_tx_serialization_with_two_signers() {
-    use crate::ids::short;
+    use crate::{ids::short, txs::transferable::TransferableOut};
 
     macro_rules! ab {
         ($e:expr) => {
@@ -159,7 +164,7 @@ fn test_tx_serialization_with_two_signers() {
         blockchain_id: ids::Id::from_slice(&<Vec<u8>>::from([5, 4, 3, 2, 1])),
         transferable_outputs: Some(vec![txs::transferable::Output {
             asset_id: ids::Id::from_slice(&<Vec<u8>>::from([1, 2, 3])),
-            transfer_output: Some(key::secp256k1::txs::transfer::Output {
+            out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                 amount: 12345,
                 output_owners: key::secp256k1::txs::OutputOwners {
                     locktime: 0,

--- a/crates/avalanche-types/src/ids/short.rs
+++ b/crates/avalanche-types/src/ids/short.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{formatting, hash, key::secp256k1};
+use crate::{formatting, hash, key::secp256k1, packer::{Packable, Packer}, errors};
 use lazy_static::lazy_static;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
@@ -123,6 +123,12 @@ impl<'de> Deserialize<'de> for Id {
         let (_, short_bytes) = secp256k1::address::avax_address_to_short_bytes("", addr)
             .map_err(serde::de::Error::custom)?;
         Ok(Id::from_slice(&short_bytes))
+    }
+}
+
+impl Packable for Id {
+    fn pack(&self, packer: &Packer) -> errors::Result<()> {
+        packer.pack_bytes(self.as_ref())
     }
 }
 

--- a/crates/avalanche-types/src/key/secp256k1/txs/transfer.rs
+++ b/crates/avalanche-types/src/key/secp256k1/txs/transfer.rs
@@ -3,7 +3,12 @@ use std::{
     io::{self, Error, ErrorKind},
 };
 
-use crate::{codec, key};
+use crate::{
+    codec,
+    errors::Result,
+    key,
+    packer::{Packable, Packer},
+};
 use serde::{Deserialize, Serialize};
 
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput>
@@ -33,6 +38,32 @@ impl Output {
 
     pub fn type_id() -> u32 {
         *(codec::X_TYPES.get(&Self::type_name()).unwrap()) as u32
+    }
+}
+
+impl Packable for Output {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        // marshal type ID for "key::secp256k1::txs::transfer::Output"
+        packer.pack_u32(Self::type_id())?;
+
+        // "key::secp256k1::txs::transfer::Output"
+        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
+
+        // marshal "secp256k1fx.TransferOutput.Amt" field
+        packer.pack_u64(self.amount)?;
+
+        // "secp256k1fx.TransferOutput.OutputOwners" is struct and serialize:"true"
+        // but embedded inline in the struct "TransferOutput"
+        // so no need to encode type ID
+        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
+        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#OutputOwners
+        packer.pack_u64(self.output_owners.locktime)?;
+        packer.pack_u32(self.output_owners.threshold)?;
+        packer.pack_u32(self.output_owners.addresses.len() as u32)?;
+        for addr in self.output_owners.addresses.iter() {
+            packer.pack_bytes(addr.as_ref())?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/avalanche-types/src/key/secp256k1/txs/transfer.rs
+++ b/crates/avalanche-types/src/key/secp256k1/txs/transfer.rs
@@ -59,10 +59,7 @@ impl Packable for Output {
         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#OutputOwners
         packer.pack_u64(self.output_owners.locktime)?;
         packer.pack_u32(self.output_owners.threshold)?;
-        packer.pack_u32(self.output_owners.addresses.len() as u32)?;
-        for addr in self.output_owners.addresses.iter() {
-            packer.pack_bytes(addr.as_ref())?;
-        }
+        packer.pack(&self.output_owners.addresses)?;
         Ok(())
     }
 }

--- a/crates/avalanche-types/src/packer/mod.rs
+++ b/crates/avalanche-types/src/packer/mod.rs
@@ -651,6 +651,13 @@ impl Packable for u8 {
     }
 }
 
+/// [`Packable`] implementation for [`u32`]
+impl Packable for u32 {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        packer.pack_u32(*self)
+    }
+}
+
 /// Generic [`Packable`] implementation for [`Option<T>`]
 impl<T: Packable> Packable for Option<T> {
     fn pack(&self, packer: &Packer) -> Result<()> {

--- a/crates/avalanche-types/src/packer/mod.rs
+++ b/crates/avalanche-types/src/packer/mod.rs
@@ -644,6 +644,36 @@ pub trait Packable {
     fn pack(&self, packer: &Packer) -> Result<()>;
 }
 
+/// [`Packable`] implementation for [`u8`]
+impl Packable for u8 {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        packer.pack_byte(*self)
+    }
+}
+
+/// Generic [`Packable`] implementation for [`Option<T>`]
+impl<T: Packable> Packable for Option<T> {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        if let Some(val) = self {
+            packer.pack(val)?;
+        } else {
+            packer.pack_u32(0_u32)?;
+        }
+        Ok(())
+    }
+}
+
+/// Generic [`Packable`] implementation for [`Vec<T>`]
+impl<T: Packable> Packable for Vec<T> {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        packer.pack_u32(self.len() as u32)?;
+        for val in self {
+            packer.pack(val)?;
+        }
+        Ok(())
+    }
+}
+
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- packer::test_expand --exact --show-output
 /// ref. "avalanchego/utils/wrappers.TestPackerExpand"
 #[test]

--- a/crates/avalanche-types/src/platformvm/txs/add_permissionless_validator.rs
+++ b/crates/avalanche-types/src/platformvm/txs/add_permissionless_validator.rs
@@ -129,24 +129,7 @@ impl Tx {
         }
 
         // pack the third field "stake" in the struct
-        if let Some(stake_transferable_outputs) = &self.stake_transferable_outputs {
-            packer.pack_u32(stake_transferable_outputs.len() as u32)?;
-
-            for transferable_output in stake_transferable_outputs.iter() {
-                // "TransferableOutput.Asset" is struct and serialize:"true"
-                // but embedded inline in the struct "TransferableOutput"
-                // so no need to encode type ID
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#Asset
-                packer.pack_bytes(transferable_output.asset_id.as_ref())?;
-
-                // fx_id is serialize:"false" thus skipping serialization
-
-                packer.pack(&transferable_output.out)?;
-            }
-        } else {
-            packer.pack_u32(0_u32)?;
-        }
+        packer.pack(&self.stake_transferable_outputs)?;
 
         // pack the fourth field "reward_owner" in the struct
         // not embedded thus encode struct type id
@@ -154,18 +137,12 @@ impl Tx {
         packer.pack_u32(output_owners_type_id)?;
         packer.pack_u64(self.validator_rewards_owner.locktime)?;
         packer.pack_u32(self.validator_rewards_owner.threshold)?;
-        packer.pack_u32(self.validator_rewards_owner.addresses.len() as u32)?;
-        for addr in self.validator_rewards_owner.addresses.iter() {
-            packer.pack_bytes(addr.as_ref())?;
-        }
+        packer.pack(&self.validator_rewards_owner.addresses)?;
 
         packer.pack_u32(output_owners_type_id)?;
         packer.pack_u64(self.delegator_rewards_owner.locktime)?;
         packer.pack_u32(self.delegator_rewards_owner.threshold)?;
-        packer.pack_u32(self.delegator_rewards_owner.addresses.len() as u32)?;
-        for addr in self.delegator_rewards_owner.addresses.iter() {
-            packer.pack_bytes(addr.as_ref())?;
-        }
+        packer.pack(&self.delegator_rewards_owner.addresses)?;
 
         // pack the fifth field "shares" in the struct
         packer.pack_u32(self.delegation_shares)?;

--- a/crates/avalanche-types/src/platformvm/txs/add_permissionless_validator.rs
+++ b/crates/avalanche-types/src/platformvm/txs/add_permissionless_validator.rs
@@ -1,7 +1,8 @@
 use crate::{
     codec,
-    errors::{Error, Result},
-    hash, ids, key, platformvm, txs,
+    errors::Result,
+    hash, ids, key, platformvm,
+    txs::{self},
 };
 use serde::{Deserialize, Serialize};
 
@@ -141,98 +142,7 @@ impl Tx {
 
                 // fx_id is serialize:"false" thus skipping serialization
 
-                // decide the type
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput
-                if transferable_output.transfer_output.is_none()
-                    && transferable_output.stakeable_lock_out.is_none()
-                {
-                    return Err(Error::Other {
-                        message: "unexpected Nones in TransferableOutput transfer_output and stakeable_lock_out".to_string(),
-                        retryable: false,
-                    });
-                }
-                let type_id_transferable_out = {
-                    if transferable_output.transfer_output.is_some() {
-                        key::secp256k1::txs::transfer::Output::type_id()
-                    } else {
-                        platformvm::txs::StakeableLockOut::type_id()
-                    }
-                };
-                // marshal type ID for "key::secp256k1::txs::transfer::Output" or "platformvm::txs::StakeableLockOut"
-                packer.pack_u32(type_id_transferable_out)?;
-
-                match type_id_transferable_out {
-                    7 => {
-                        // "key::secp256k1::txs::transfer::Output"
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                        let transfer_output = transferable_output.transfer_output.clone().unwrap();
-
-                        // marshal "secp256k1fx.TransferOutput.Amt" field
-                        packer.pack_u64(transfer_output.amount)?;
-
-                        // "secp256k1fx.TransferOutput.OutputOwners" is struct and serialize:"true"
-                        // but embedded inline in the struct "TransferOutput"
-                        // so no need to encode type ID
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#OutputOwners
-                        packer.pack_u64(transfer_output.output_owners.locktime)?;
-                        packer.pack_u32(transfer_output.output_owners.threshold)?;
-                        packer.pack_u32(transfer_output.output_owners.addresses.len() as u32)?;
-                        for addr in transfer_output.output_owners.addresses.iter() {
-                            packer.pack_bytes(addr.as_ref())?;
-                        }
-                    }
-                    22 => {
-                        // "platformvm::txs::StakeableLockOut"
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut
-                        let stakeable_lock_out =
-                            transferable_output.stakeable_lock_out.clone().unwrap();
-
-                        // marshal "platformvm::txs::StakeableLockOut.locktime" field
-                        packer.pack_u64(stakeable_lock_out.locktime)?;
-
-                        // secp256k1fx.TransferOutput type ID
-                        packer.pack_u32(7)?;
-
-                        // "platformvm.StakeableLockOut.TransferOutput" is struct and serialize:"true"
-                        // but embedded inline in the struct "StakeableLockOut"
-                        // so no need to encode type ID
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#OutputOwners
-                        //
-                        // marshal "secp256k1fx.TransferOutput.Amt" field
-                        packer.pack_u64(stakeable_lock_out.transfer_output.amount)?;
-                        packer
-                            .pack_u64(stakeable_lock_out.transfer_output.output_owners.locktime)?;
-                        packer
-                            .pack_u32(stakeable_lock_out.transfer_output.output_owners.threshold)?;
-                        packer.pack_u32(
-                            stakeable_lock_out
-                                .transfer_output
-                                .output_owners
-                                .addresses
-                                .len() as u32,
-                        )?;
-                        for addr in stakeable_lock_out
-                            .transfer_output
-                            .output_owners
-                            .addresses
-                            .iter()
-                        {
-                            packer.pack_bytes(addr.as_ref())?;
-                        }
-                    }
-                    _ => {
-                        return Err(Error::Other {
-                            message: format!(
-                                "unexpected type ID {} for TransferableOutput",
-                                type_id_transferable_out
-                            ),
-                            retryable: false,
-                        });
-                    }
-                }
+                packer.pack(&transferable_output.out)?;
             }
         } else {
             packer.pack_u32(0_u32)?;
@@ -324,7 +234,10 @@ impl Tx {
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- platformvm::txs::add_permissionless_validator::test_add_permissionless_validator_tx_serialization_with_one_signer --exact --show-output
 #[test]
 fn test_add_permissionless_validator_tx_serialization_with_one_signer() {
-    use crate::ids::{node, short};
+    use crate::{
+        ids::{node, short},
+        txs::transferable::TransferableOut,
+    };
     use std::str::FromStr;
 
     let _ = env_logger::builder()
@@ -353,7 +266,7 @@ fn test_add_permissionless_validator_tx_serialization_with_one_signer() {
                     0xe8, 0x5e, 0xa5, 0x74, 0xc7, 0xa1, 0x5a, 0x79, //
                     0x68, 0x64, 0x4d, 0x14, 0xd5, 0x47, 0x80, 0x14, //
                 ])),
-                transfer_output: Some(key::secp256k1::txs::transfer::Output {
+                out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                     amount: 0x2c6874d687fc000,
                     output_owners: key::secp256k1::txs::OutputOwners {
                         locktime: 0,
@@ -407,7 +320,7 @@ fn test_add_permissionless_validator_tx_serialization_with_one_signer() {
                 0xe8, 0x5e, 0xa5, 0x74, 0xc7, 0xa1, 0x5a, 0x79, //
                 0x68, 0x64, 0x4d, 0x14, 0xd5, 0x47, 0x80, 0x14, //
             ])),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut{
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut{
                 locktime:0,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: 0x7e7,

--- a/crates/avalanche-types/src/platformvm/txs/add_subnet_validator.rs
+++ b/crates/avalanche-types/src/platformvm/txs/add_subnet_validator.rs
@@ -157,7 +157,10 @@ impl Tx {
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- platformvm::txs::add_subnet_validator::test_add_subnet_validator_tx_serialization_with_one_signer --exact --show-output
 #[test]
 fn test_add_subnet_validator_tx_serialization_with_one_signer() {
-    use crate::ids::{node, short};
+    use crate::{
+        ids::{node, short},
+        txs::transferable::TransferableOut,
+    };
 
     macro_rules! ab {
         ($e:expr) => {
@@ -175,7 +178,7 @@ fn test_add_subnet_validator_tx_serialization_with_one_signer() {
                     0xe8, 0x5e, 0xa5, 0x74, 0xc7, 0xa1, 0x5a, 0x79, //
                     0x68, 0x64, 0x4d, 0x14, 0xd5, 0x47, 0x80, 0x14, //
                 ])),
-                transfer_output: Some(key::secp256k1::txs::transfer::Output {
+                out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                     amount: 0x2c6874d5c56f500,
                     output_owners: key::secp256k1::txs::OutputOwners {
                         locktime: 0x00,

--- a/crates/avalanche-types/src/platformvm/txs/add_subnet_validator.rs
+++ b/crates/avalanche-types/src/platformvm/txs/add_subnet_validator.rs
@@ -88,10 +88,7 @@ impl Tx {
         // pack the third field "subnet_auth" in the struct
         let subnet_auth_type_id = key::secp256k1::txs::Input::type_id();
         packer.pack_u32(subnet_auth_type_id)?;
-        packer.pack_u32(self.subnet_auth.sig_indices.len() as u32)?;
-        for sig_idx in self.subnet_auth.sig_indices.iter() {
-            packer.pack_u32(*sig_idx)?;
-        }
+        packer.pack(&self.subnet_auth.sig_indices)?;
 
         // take bytes just for hashing computation
         let tx_bytes_with_no_signature = packer.take_bytes();

--- a/crates/avalanche-types/src/platformvm/txs/add_validator.rs
+++ b/crates/avalanche-types/src/platformvm/txs/add_validator.rs
@@ -149,10 +149,7 @@ impl packer::Packable for Tx {
         packer.pack_u32(output_owners_type_id)?;
         packer.pack_u64(self.rewards_owner.locktime)?;
         packer.pack_u32(self.rewards_owner.threshold)?;
-        packer.pack_u32(self.rewards_owner.addresses.len() as u32)?;
-        for addr in self.rewards_owner.addresses.iter() {
-            packer.pack_bytes(addr.as_ref())?;
-        }
+        packer.pack(&self.rewards_owner.addresses)?;
 
         // pack the fifth field "shares" in the struct
         packer.pack_u32(self.shares)?;

--- a/crates/avalanche-types/src/platformvm/txs/add_validator.rs
+++ b/crates/avalanche-types/src/platformvm/txs/add_validator.rs
@@ -141,25 +141,7 @@ impl packer::Packable for Tx {
         packer.pack_u64(self.validator.weight)?;
 
         // pack the third field "stake" in the struct
-        if self.stake_transferable_outputs.is_some() {
-            let stake_transferable_outputs = self.stake_transferable_outputs.as_ref().unwrap();
-            packer.pack_u32(stake_transferable_outputs.len() as u32)?;
-
-            for transferable_output in stake_transferable_outputs.iter() {
-                // "TransferableOutput.Asset" is struct and serialize:"true"
-                // but embedded inline in the struct "TransferableOutput"
-                // so no need to encode type ID
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#Asset
-                packer.pack_bytes(transferable_output.asset_id.as_ref())?;
-
-                // fx_id is serialize:"false" thus skipping serialization
-
-                packer.pack(&transferable_output.out)?;
-            }
-        } else {
-            packer.pack_u32(0_u32)?;
-        }
+        packer.pack(&self.stake_transferable_outputs)?;
 
         // pack the fourth field "reward_owner" in the struct
         // not embedded thus encode struct type id

--- a/crates/avalanche-types/src/platformvm/txs/create_chain.rs
+++ b/crates/avalanche-types/src/platformvm/txs/create_chain.rs
@@ -1,4 +1,9 @@
-use crate::{codec, errors::Result, hash, ids, key, txs};
+use crate::{
+    codec,
+    errors::Result,
+    hash, ids, key,
+    txs::{self},
+};
 use serde::{Deserialize, Serialize};
 
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm/txs#CreateChainTx>
@@ -180,7 +185,7 @@ impl Tx {
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- platformvm::txs::create_chain::test_create_chain_tx_serialization_with_one_signer --exact --show-output
 #[test]
 fn test_create_chain_tx_serialization_with_one_signer() {
-    use crate::ids::short;
+    use crate::{ids::short, txs::transferable::TransferableOut};
 
     macro_rules! ab {
         ($e:expr) => {
@@ -198,7 +203,7 @@ fn test_create_chain_tx_serialization_with_one_signer() {
                     0xe8, 0x5e, 0xa5, 0x74, 0xc7, 0xa1, 0x5a, 0x79, //
                     0x68, 0x64, 0x4d, 0x14, 0xd5, 0x47, 0x80, 0x14, //
                 ])),
-                transfer_output: Some(key::secp256k1::txs::transfer::Output {
+                out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                     amount: 0x2c6874d5c56f500,
                     output_owners: key::secp256k1::txs::OutputOwners {
                         locktime: 0x00,

--- a/crates/avalanche-types/src/platformvm/txs/create_chain.rs
+++ b/crates/avalanche-types/src/platformvm/txs/create_chain.rs
@@ -116,10 +116,7 @@ impl Tx {
         // pack the seventh field "subnet_auth" in the struct
         let subnet_auth_type_id = key::secp256k1::txs::Input::type_id();
         packer.pack_u32(subnet_auth_type_id)?;
-        packer.pack_u32(self.subnet_auth.sig_indices.len() as u32)?;
-        for sig_idx in self.subnet_auth.sig_indices.iter() {
-            packer.pack_u32(*sig_idx)?;
-        }
+        packer.pack(&self.subnet_auth.sig_indices)?;
 
         // take bytes just for hashing computation
         let tx_bytes_with_no_signature = packer.take_bytes();

--- a/crates/avalanche-types/src/platformvm/txs/create_subnet.rs
+++ b/crates/avalanche-types/src/platformvm/txs/create_subnet.rs
@@ -73,10 +73,7 @@ impl Tx {
         packer.pack_u32(output_owners_type_id)?;
         packer.pack_u64(self.owner.locktime)?;
         packer.pack_u32(self.owner.threshold)?;
-        packer.pack_u32(self.owner.addresses.len() as u32)?;
-        for addr in self.owner.addresses.iter() {
-            packer.pack_bytes(addr.as_ref())?;
-        }
+        packer.pack(&self.owner.addresses)?;
 
         // take bytes just for hashing computation
         let tx_bytes_with_no_signature = packer.take_bytes();

--- a/crates/avalanche-types/src/platformvm/txs/create_subnet.rs
+++ b/crates/avalanche-types/src/platformvm/txs/create_subnet.rs
@@ -1,4 +1,9 @@
-use crate::{codec, errors::Result, hash, ids, key, txs};
+use crate::{
+    codec,
+    errors::Result,
+    hash, ids, key,
+    txs::{self},
+};
 use serde::{Deserialize, Serialize};
 
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm/txs#CreateSubnetTx>
@@ -137,7 +142,7 @@ impl Tx {
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- platformvm::txs::create_subnet::test_create_subnet_tx_serialization_with_one_signer --exact --show-output
 #[test]
 fn test_create_subnet_tx_serialization_with_one_signer() {
-    use crate::ids::short;
+    use crate::{ids::short, txs::transferable::TransferableOut};
 
     macro_rules! ab {
         ($e:expr) => {
@@ -155,7 +160,7 @@ fn test_create_subnet_tx_serialization_with_one_signer() {
                     0xd3, 0x84, 0x9b, 0xb9, 0xdf, 0xab, 0xe3, 0x9f, //
                     0xcb, 0xc3, 0xe7, 0xee, 0x88, 0x11, 0xfe, 0x2f, //
                 ])),
-                transfer_output: Some(key::secp256k1::txs::transfer::Output {
+                out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                     amount: 0x2386f269cb1f00,
                     output_owners: key::secp256k1::txs::OutputOwners {
                         locktime: 0x00,
@@ -340,7 +345,7 @@ fn test_create_subnet_tx_serialization_with_one_signer() {
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- platformvm::txs::create_subnet::test_create_subnet_tx_serialization_with_custom_network --exact --show-output
 #[test]
 fn test_create_subnet_tx_serialization_with_custom_network() {
-    use crate::ids::short;
+    use crate::{ids::short, txs::transferable::TransferableOut};
 
     macro_rules! ab {
         ($e:expr) => {
@@ -358,7 +363,7 @@ fn test_create_subnet_tx_serialization_with_custom_network() {
                     0xe8, 0x5e, 0xa5, 0x74, 0xc7, 0xa1, 0x5a, 0x79, //
                     0x68, 0x64, 0x4d, 0x14, 0xd5, 0x47, 0x80, 0x14, //
                 ])),
-                transfer_output: Some(key::secp256k1::txs::transfer::Output {
+                out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                     amount: 0x2c6874d5c663740,
                     output_owners: key::secp256k1::txs::OutputOwners {
                         locktime: 0x00,

--- a/crates/avalanche-types/src/txs/mod.rs
+++ b/crates/avalanche-types/src/txs/mod.rs
@@ -155,10 +155,7 @@ impl packer::Packable for Tx {
                         // so no need to encode type ID
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferInput
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#Input
-                        packer.pack_u32(transfer_input.sig_indices.len() as u32)?;
-                        for idx in transfer_input.sig_indices.iter() {
-                            packer.pack_u32(*idx)?;
-                        }
+                        packer.pack(&transfer_input.sig_indices)?;
                     }
                     21 => {
                         // "platformvm::txs::StakeableLockIn"
@@ -184,11 +181,7 @@ impl packer::Packable for Tx {
                         // so no need to encode type ID
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferInput
                         // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#Input
-                        packer
-                            .pack_u32(stakeable_lock_in.transfer_input.sig_indices.len() as u32)?;
-                        for idx in stakeable_lock_in.transfer_input.sig_indices.iter() {
-                            packer.pack_u32(*idx)?;
-                        }
+                        packer.pack(&stakeable_lock_in.transfer_input.sig_indices)?;
                     }
                     _ => {
                         return Err(Error::Other {

--- a/crates/avalanche-types/src/txs/transferable.rs
+++ b/crates/avalanche-types/src/txs/transferable.rs
@@ -132,6 +132,19 @@ impl PartialEq for Output {
     }
 }
 
+impl Packable for Output {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        // "TransferableOutput.Asset" is struct and serialize:"true"
+        // but embedded inline in the struct "TransferableOutput"
+        // so no need to encode type ID
+        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput
+        // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#Asset
+        packer.pack_bytes(self.asset_id.as_ref())?;
+        packer.pack(&self.out)?;
+        Ok(())
+    }
+}
+
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#SortTransferableOutputs>
 /// ref. "avalanchego/vms/components/avax.TestTransferableOutputSorting"
 /// RUST_LOG=debug cargo test --package avalanche-types --lib -- txs::transferable::test_sort_transferable_outputs --exact --show-output

--- a/crates/avalanche-types/src/txs/transferable.rs
+++ b/crates/avalanche-types/src/txs/transferable.rs
@@ -1,7 +1,85 @@
 use std::cmp::Ordering;
 
-use crate::{ids, key, platformvm, txs};
+use crate::{
+    errors::Result,
+    ids, key,
+    packer::{Packable, Packer},
+    platformvm, txs,
+};
 use serde::{Deserialize, Serialize};
+
+/// Implementation of "*components.avax.TransferOut"
+/// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOut>
+/// which is either:
+///
+/// "*secp256k1fx.TransferOutput"
+/// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput>
+///
+/// "*platformvm.StakeableLockOut" which embeds "*secp256k1fx.TransferOutput"
+/// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut>
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, PartialOrd)]
+#[serde(untagged)]
+pub enum TransferableOut {
+    TransferOutput(key::secp256k1::txs::transfer::Output),
+    StakeableLockOut(platformvm::txs::StakeableLockOut),
+}
+
+impl TransferableOut {
+    pub fn type_id(&self) -> u32 {
+        match self {
+            TransferableOut::TransferOutput(_out) => {
+                key::secp256k1::txs::transfer::Output::type_id()
+            }
+            TransferableOut::StakeableLockOut(_out) => platformvm::txs::StakeableLockOut::type_id(),
+        }
+    }
+}
+
+impl Packable for TransferableOut {
+    fn pack(&self, packer: &Packer) -> Result<()> {
+        match self {
+            TransferableOut::TransferOutput(transfer_output) => {
+                packer.pack(transfer_output)?;
+            }
+            TransferableOut::StakeableLockOut(stakeable_lock_out) => {
+                // marshal type ID "platformvm::txs::StakeableLockOut"
+                packer.pack_u32(platformvm::txs::StakeableLockOut::type_id())?;
+
+                // "platformvm::txs::StakeableLockOut"
+                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut
+
+                // marshal "platformvm::txs::StakeableLockOut.locktime" field
+                packer.pack_u64(stakeable_lock_out.locktime)?;
+                packer.pack(&stakeable_lock_out.transfer_output)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Ord for TransferableOut {
+    fn cmp(&self, other: &TransferableOut) -> Ordering {
+        // unlike "avalanchego", we want ordering without "codec" dependency and marshal-ing
+        // just check type ID header
+        let type_id_ord = self.type_id().cmp(&other.type_id());
+        if type_id_ord != Ordering::Equal {
+            // no need to compare further
+            return type_id_ord;
+        }
+
+        match (self, other) {
+            (
+                TransferableOut::TransferOutput(out_self),
+                TransferableOut::TransferOutput(out_other),
+            ) => out_self.cmp(out_other),
+            (
+                TransferableOut::StakeableLockOut(out_self),
+                TransferableOut::StakeableLockOut(out_other),
+            ) => out_self.cmp(out_other),
+            (_, _) => self.type_id().cmp(&other.type_id()),
+        }
+    }
+}
 
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOutput>
 /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/components/avax#TransferableOut>
@@ -15,18 +93,8 @@ pub struct Output {
     #[serde(rename = "fxID", skip_serializing_if = "Option::is_none")]
     pub fx_id: Option<ids::Id>,
 
-    /// The underlying type is one of the following:
-    ///
-    /// "*secp256k1fx.TransferOutput"
-    /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput>
-    ///
-    /// "*platformvm.StakeableLockOut" which embeds "*secp256k1fx.TransferOutput"
-    /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut>
-    ///
-    /// MUST: only one of the following can be "Some".
     #[serde(rename = "output")]
-    pub transfer_output: Option<key::secp256k1::txs::transfer::Output>,
-    pub stakeable_lock_out: Option<platformvm::txs::StakeableLockOut>,
+    pub out: TransferableOut,
 }
 
 impl Default for Output {
@@ -34,8 +102,7 @@ impl Default for Output {
         Self {
             asset_id: ids::Id::empty(),
             fx_id: None,
-            transfer_output: None,
-            stakeable_lock_out: None,
+            out: TransferableOut::TransferOutput(Default::default()),
         }
     }
 }
@@ -48,60 +115,8 @@ impl Ord for Output {
             // no need to compare further
             return asset_id_ord;
         }
-        if self.transfer_output.is_none()
-            && self.stakeable_lock_out.is_none()
-            && other.transfer_output.is_none()
-            && other.stakeable_lock_out.is_none()
-        {
-            // should never happen but sorting/ordering shouldn't worry about this...
-            // can't compare anymore, so thus return here...
-            return Ordering::Equal;
-        }
 
-        // unlike "avalanchego", we want ordering without "codec" dependency and marshal-ing
-        // just check type ID header
-        let type_id_self = {
-            if self.transfer_output.is_some() {
-                key::secp256k1::txs::transfer::Output::type_id()
-            } else {
-                platformvm::txs::StakeableLockOut::type_id()
-            }
-        };
-        let type_id_other = {
-            if other.transfer_output.is_some() {
-                key::secp256k1::txs::transfer::Output::type_id()
-            } else {
-                platformvm::txs::StakeableLockOut::type_id()
-            }
-        };
-        let type_id_ord = type_id_self.cmp(&type_id_other);
-        if type_id_ord != Ordering::Equal {
-            // no need to compare further
-            return type_id_ord;
-        }
-
-        // both instances have the same type!!!
-        // just use the ordering of underlying types
-        match type_id_self {
-            7 => {
-                // "key::secp256k1::txs::transfer::Output"
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/secp256k1fx#TransferOutput
-                let transfer_output_self = self.transfer_output.clone().unwrap();
-                let transfer_output_other = other.transfer_output.clone().unwrap();
-                transfer_output_self.cmp(&transfer_output_other)
-            }
-            22 => {
-                // "platformvm::txs::StakeableLockOut"
-                // ref. https://pkg.go.dev/github.com/ava-labs/avalanchego/vms/platformvm#StakeableLockOut
-                let stakeable_lock_out_self = self.stakeable_lock_out.clone().unwrap();
-                let stakeable_lock_out_other = other.stakeable_lock_out.clone().unwrap();
-                stakeable_lock_out_self.cmp(&stakeable_lock_out_other)
-            }
-            _ => {
-                // should never happen
-                panic!("unexpected type ID {} for TransferableOutput", type_id_self);
-            }
-        }
+        self.out.cmp(&other.out)
     }
 }
 
@@ -128,7 +143,7 @@ fn test_sort_transferable_outputs() {
     for i in (0..10).rev() {
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -146,7 +161,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -164,7 +179,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -179,7 +194,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: i as u64,
@@ -194,7 +209,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            transfer_output: Some(key::secp256k1::txs::transfer::Output {
+            out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                 amount: i as u64,
                 output_owners: key::secp256k1::txs::OutputOwners {
                     locktime: i as u64,
@@ -206,7 +221,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -221,7 +236,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: i as u64,
@@ -236,7 +251,7 @@ fn test_sort_transferable_outputs() {
         });
         outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            transfer_output: Some(key::secp256k1::txs::transfer::Output {
+            out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                 amount: i as u64,
                 output_owners: key::secp256k1::txs::OutputOwners {
                     locktime: i as u64,
@@ -254,7 +269,7 @@ fn test_sort_transferable_outputs() {
     for i in 0..10 {
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            transfer_output: Some(key::secp256k1::txs::transfer::Output {
+            out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                 amount: i as u64,
                 output_owners: key::secp256k1::txs::OutputOwners {
                     locktime: i as u64,
@@ -266,7 +281,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: i as u64,
@@ -281,7 +296,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -296,7 +311,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            transfer_output: Some(key::secp256k1::txs::transfer::Output {
+            out: TransferableOut::TransferOutput(key::secp256k1::txs::transfer::Output {
                 amount: i as u64,
                 output_owners: key::secp256k1::txs::OutputOwners {
                     locktime: i as u64,
@@ -308,7 +323,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: i as u64,
@@ -323,7 +338,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -338,7 +353,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,
@@ -356,7 +371,7 @@ fn test_sort_transferable_outputs() {
         });
         sorted_outputs.push(Output {
             asset_id: ids::Id::from_slice(&[i as u8, 2, 2, 3, 4, 5, 6, 7, 8, 9]),
-            stakeable_lock_out: Some(platformvm::txs::StakeableLockOut {
+            out: TransferableOut::StakeableLockOut(platformvm::txs::StakeableLockOut {
                 locktime: i as u64,
                 transfer_output: key::secp256k1::txs::transfer::Output {
                     amount: (i + 1) as u64,

--- a/crates/avalanche-types/src/txs/utxo.rs
+++ b/crates/avalanche-types/src/txs/utxo.rs
@@ -208,10 +208,7 @@ impl Utxo {
             packer.pack_u64(out.output_owners.locktime)?;
             packer.pack_u32(out.output_owners.threshold)?;
 
-            packer.pack_u32(out.output_owners.addresses.len() as u32)?;
-            for addr in out.output_owners.addresses.iter() {
-                packer.pack_bytes(addr.as_ref())?;
-            }
+            packer.pack(&out.output_owners.addresses)?;
         } else if let Some(lock_out) = &self.stakeable_lock_out {
             packer.pack_u32(platformvm::txs::StakeableLockOut::type_id())?;
             packer.pack_u64(lock_out.locktime)?;
@@ -222,10 +219,7 @@ impl Utxo {
             packer.pack_u64(lock_out.transfer_output.output_owners.locktime)?;
             packer.pack_u32(lock_out.transfer_output.output_owners.threshold)?;
 
-            packer.pack_u32(lock_out.transfer_output.output_owners.addresses.len() as u32)?;
-            for addr in lock_out.transfer_output.output_owners.addresses.iter() {
-                packer.pack_bytes(addr.as_ref())?;
-            }
+            packer.pack(&lock_out.transfer_output.output_owners.addresses)?;
         }
 
         Ok(packer)

--- a/crates/avalanche-types/src/txs/utxo.rs
+++ b/crates/avalanche-types/src/txs/utxo.rs
@@ -131,7 +131,9 @@ fn test_utxo_id() {
 /// TODO: implement ordering?
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct Utxo {
+    #[serde(flatten)]
     pub utxo_id: Id,
+    #[serde(rename = "assetID")]
     pub asset_id: ids::Id,
 
     /// AvalancheGo loads "avax.UTXO" object from the db and


### PR DESCRIPTION
This fixes the (de)serialization of tranferable outputs by refactoring outputs to be represented by an enum instead of two `Option` fields. This refactoring has several advantages:

- Allows the use of `#[serde(untagged)]` for (de)serializing outputs
- Makes it explicit that one of the two output types has to be present (before, deserialization could succeed if the output field could not be parsed)
- Simplifies code that handles outputs

This change also removes some of the code repetition