### PR TITLE
Fix clippy warnings in codec module

### DIFF
--- a/crates/avalanche-types/src/codec/serde/base64_bytes.rs
+++ b/crates/avalanche-types/src/codec/serde/base64_bytes.rs
@@ -19,7 +19,7 @@ where
         .map_err(serde::de::Error::custom)
 }
 
-pub struct Base64Bytes(Vec<u8>);
+pub struct Base64Bytes;
 
 impl SerializeAs<Vec<u8>> for Base64Bytes {
     fn serialize_as<S>(x: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/hex_0x_big_int.rs
+++ b/crates/avalanche-types/src/codec/serde/hex_0x_big_int.rs
@@ -20,7 +20,7 @@ where
     from_hex_to_big_int(&s).map_err(serde::de::Error::custom)
 }
 
-pub struct Hex0xBigInt(BigInt);
+pub struct Hex0xBigInt;
 
 impl SerializeAs<BigInt> for Hex0xBigInt {
     fn serialize_as<S>(x: &BigInt, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/hex_0x_primitive_types_h160.rs
+++ b/crates/avalanche-types/src/codec/serde/hex_0x_primitive_types_h160.rs
@@ -21,7 +21,7 @@ where
     H160::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub struct Hex0xH160(H160);
+pub struct Hex0xH160;
 
 impl SerializeAs<H160> for Hex0xH160 {
     fn serialize_as<S>(x: &H160, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/hex_0x_primitive_types_h256.rs
+++ b/crates/avalanche-types/src/codec/serde/hex_0x_primitive_types_h256.rs
@@ -21,7 +21,7 @@ where
     H256::from_str(s).map_err(serde::de::Error::custom)
 }
 
-pub struct Hex0xH256(H256);
+pub struct Hex0xH256;
 
 impl SerializeAs<H256> for Hex0xH256 {
     fn serialize_as<S>(x: &H256, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/hex_0x_primitive_types_u256.rs
+++ b/crates/avalanche-types/src/codec/serde/hex_0x_primitive_types_u256.rs
@@ -19,7 +19,7 @@ where
     U256::from_str_radix(s, 16).map_err(serde::de::Error::custom)
 }
 
-pub struct Hex0xU256(U256);
+pub struct Hex0xU256;
 
 impl SerializeAs<U256> for Hex0xU256 {
     fn serialize_as<S>(x: &U256, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/hex_0x_u64.rs
+++ b/crates/avalanche-types/src/codec/serde/hex_0x_u64.rs
@@ -18,7 +18,7 @@ where
     u64::from_str_radix(s, 16).map_err(serde::de::Error::custom)
 }
 
-pub struct Hex0xU64(u64);
+pub struct Hex0xU64;
 
 impl SerializeAs<u64> for Hex0xU64 {
     fn serialize_as<S>(x: &u64, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/hex_0x_utxo.rs
+++ b/crates/avalanche-types/src/codec/serde/hex_0x_utxo.rs
@@ -19,7 +19,7 @@ where
     Utxo::from_hex(&s).map_err(serde::de::Error::custom)
 }
 
-pub struct Hex0xUtxo(Utxo);
+pub struct Hex0xUtxo;
 
 impl SerializeAs<Utxo> for Hex0xUtxo {
     fn serialize_as<S>(x: &Utxo, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/ip_port.rs
+++ b/crates/avalanche-types/src/codec/serde/ip_port.rs
@@ -42,7 +42,7 @@ where
     }
 }
 
-pub struct IpPort(SocketAddr);
+pub struct IpPort;
 
 impl SerializeAs<SocketAddr> for IpPort {
     fn serialize_as<S>(x: &SocketAddr, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/avalanche-types/src/codec/serde/rfc_3339.rs
+++ b/crates/avalanche-types/src/codec/serde/rfc_3339.rs
@@ -25,7 +25,7 @@ where
     }
 }
 
-pub struct DateTimeUtc(DateTime<Utc>);
+pub struct DateTimeUtc;
 
 impl SerializeAs<DateTime<Utc>> for DateTimeUtc {
     fn serialize_as<S>(x: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
I'm guessing these warnings were because of a new Rust release

