### PR TITLE
Remove fields deprecated in AvalancheGo v1.11.11

### DIFF
--- a/crates/avalanche-types/src/avalanchego/genesis.rs
+++ b/crates/avalanche-types/src/avalanchego/genesis.rs
@@ -5,7 +5,6 @@ use std::{
     io::{self, Error, ErrorKind, Write},
     path::Path,
     time::SystemTime,
-    u64,
 };
 
 use crate::{constants, coreth::genesis as coreth_genesis, key};

--- a/crates/avalanche-types/src/codec/serde/ip_port.rs
+++ b/crates/avalanche-types/src/codec/serde/ip_port.rs
@@ -32,11 +32,7 @@ where
                 return Err(serde::de::Error::custom("no host found"));
             };
             let ip: IpAddr = host.parse().map_err(serde::de::Error::custom)?;
-            let port = if let Some(port) = url.port() {
-                port
-            } else {
-                0 // e.g., DNS
-            };
+            let port = url.port().unwrap_or(0);
             Ok(SocketAddr::new(ip, port))
         }
     }
@@ -72,11 +68,7 @@ impl<'de> DeserializeAs<'de, SocketAddr> for IpPort {
                     return Err(serde::de::Error::custom("no host found"));
                 };
                 let ip: IpAddr = host.parse().map_err(serde::de::Error::custom)?;
-                let port = if let Some(port) = url.port() {
-                    port
-                } else {
-                    0 // e.g., DNS
-                };
+                let port = url.port().unwrap_or(0);
                 Ok(SocketAddr::new(ip, port))
             }
         }

--- a/crates/avalanche-types/src/jsonrpc/info.rs
+++ b/crates/avalanche-types/src/jsonrpc/info.rs
@@ -645,8 +645,6 @@ pub struct Peer {
     pub last_received: DateTime<Utc>,
     #[serde_as(as = "DisplayFromStr")]
     pub observed_uptime: u32,
-    #[serde_as(as = "HashMap<_, DisplayFromStr>")]
-    pub observed_subnet_uptimes: HashMap<ids::Id, u32>,
     pub tracked_subnets: Vec<ids::Id>,
 }
 
@@ -660,7 +658,6 @@ impl Default for Peer {
             last_sent: DateTime::<Utc>::MIN_UTC,
             last_received: DateTime::<Utc>::MIN_UTC,
             observed_uptime: 0,
-            observed_subnet_uptimes: HashMap::new(),
             tracked_subnets: Vec::new(),
         }
     }
@@ -691,7 +688,6 @@ fn test_peers() {
                 \"lastReceived\": \"2020-06-01T15:22:57Z\",
                 \"benched\": [],
                 \"observedUptime\": \"99\",
-                \"observedSubnetUptimes\": {},
                 \"trackedSubnets\": [],
                 \"benched\": []
             },
@@ -704,9 +700,6 @@ fn test_peers() {
                 \"lastReceived\": \"2020-06-01T15:22:34Z\",
                 \"benched\": [],
                 \"observedUptime\": \"75\",
-                \"observedSubnetUptimes\": {
-                    \"29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL\": \"100\"
-                },
                 \"trackedSubnets\": [
                     \"29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL\"
                 ],
@@ -721,13 +714,6 @@ fn test_peers() {
     )
     .unwrap();
 
-    let uptimes: HashMap<ids::Id, u32> = [(
-        ids::Id::from_str("29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL").unwrap(),
-        100,
-    )]
-    .iter()
-    .cloned()
-    .collect();
     let expected = PeersResponse {
         jsonrpc: "2.0".to_string(),
         id: 1,
@@ -770,7 +756,6 @@ fn test_peers() {
                             .naive_utc(),
                     ),
                     observed_uptime: 75,
-                    observed_subnet_uptimes: uptimes,
                     tracked_subnets: vec![ids::Id::from_str(
                         "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL",
                     )

--- a/crates/avalanche-types/src/jsonrpc/platformvm.rs
+++ b/crates/avalanche-types/src/jsonrpc/platformvm.rs
@@ -731,7 +731,7 @@ pub struct ApiPrimaryValidator {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uptime: Option<f32>,
-    pub connected: bool,
+    pub connected: Option<bool>,
 
     /// None for permissioned Subnet validator
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -765,7 +765,7 @@ impl Default for ApiPrimaryValidator {
             potential_reward: None,
             delegation_fee: None,
             uptime: None,
-            connected: false,
+            connected: None,
             signer: None,
             delegator_count: None,
             delegator_weight: None,
@@ -935,7 +935,7 @@ fn test_get_current_validators() {
                     potential_reward: Some(79984390135364555),
                     delegation_fee: Some(6.25),
                     uptime: Some(100.0),
-                    connected: true,
+                    connected: Some(true),
                     delegator_count: Some(0),
                     delegator_weight: Some(0),
                     ..ApiPrimaryValidator::default()
@@ -966,7 +966,7 @@ fn test_get_current_validators() {
                     potential_reward: Some(77148186230865960),
                     delegation_fee: Some(6.25),
                     uptime: Some(100.0),
-                    connected: true,
+                    connected: Some(true),
                     delegator_count: Some(0),
                     delegator_weight: Some(0),
                     ..ApiPrimaryValidator::default()
@@ -1029,7 +1029,7 @@ fn test_get_pending_validators() {
                 stake_amount: Some(200000000000),
                 node_id: node::Id::from_str("NodeID-5mb46qkSBj81k9g9e4VFjGGSbaaSLFRzD").unwrap(),
                 delegation_fee: Some(10.0),
-                connected: false,
+                connected: Some(false),
                 ..ApiPrimaryValidator::default()
             }]),
             delegators: <Vec<ApiPrimaryDelegator>>::from([ApiPrimaryDelegator {

--- a/crates/avalanche-types/src/key/secp256k1/mod.rs
+++ b/crates/avalanche-types/src/key/secp256k1/mod.rs
@@ -332,7 +332,7 @@ fn test_keys_address() {
             log::info!("checking the key info at {}", pos);
 
             let sk = crate::key::secp256k1::private_key::Key::from_cb58(
-                &ki.private_key_cb58.clone().unwrap(),
+                ki.private_key_cb58.clone().unwrap(),
             )
             .unwrap();
             assert_eq!(

--- a/crates/avalanche-types/src/key/secp256k1/private_key.rs
+++ b/crates/avalanche-types/src/key/secp256k1/private_key.rs
@@ -369,7 +369,7 @@ pub fn load_cb58_keys(d: &[u8], permute_keys: bool) -> Result<Vec<Key>> {
     let mut added = HashMap::new();
     loop {
         if let Some(s) = lines.next() {
-            if added.get(s).is_some() {
+            if added.contains_key(s) {
                 return Err(Error::Other {
                     message: format!("key at line {} already added before", line_cnt),
                     retryable: false,

--- a/crates/avalanche-types/src/packer/mod.rs
+++ b/crates/avalanche-types/src/packer/mod.rs
@@ -1,7 +1,7 @@
 //! Low-level byte-packing utilities.
 pub mod ip;
 
-use std::{cell::Cell, u16};
+use std::cell::Cell;
 
 use crate::errors::{Error, Result};
 use bytes::{Buf, BufMut, Bytes, BytesMut};

--- a/crates/avalanche-types/src/subnet/rpc/database/mod.rs
+++ b/crates/avalanche-types/src/subnet/rpc/database/mod.rs
@@ -41,6 +41,7 @@ pub trait KeyValueReaderWriterDeleter {
 // Trait that specifies that something may be
 // committed.
 #[tonic::async_trait]
+#[allow(dead_code)]
 trait Commitable {
     /// Writes all the operations of this database to the underlying database.
     async fn commit(&mut self) -> Result<()>;

--- a/tests/avalanche-e2e/src/x/simple_transfers.rs
+++ b/tests/avalanche-e2e/src/x/simple_transfers.rs
@@ -321,26 +321,23 @@ async fn make_single_transfer(
             }
         };
         let matched = prometheus_manager::find_all(&s.metrics, |s| {
-            s.metric
-                .contains("avalanche_X_vm_avalanche_base_txs_accepted")
+            s.metric.contains("avalanche_avm_txs_accepted")
+                && s.labels.as_ref().unwrap().get("chain") == Some("X")
+                && s.labels.as_ref().unwrap().get("tx") == Some("base")
         });
+        log::info!("matched {:?}", matched);
         let mut cur: HashMap<String, f64> = HashMap::new();
         for m in matched {
             cur.insert(m.metric.clone(), m.value.to_f64());
         }
 
-        if *cur
-            .get("avalanche_X_vm_avalanche_base_txs_accepted")
-            .unwrap()
-            == 0_f64
-        {
+        if *cur.get("avalanche_avm_txs_accepted").unwrap() == 0_f64 {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 format!(
-                    "{} unexpected 'avalanche_X_vm_avalanche_base_txs_accepted' {}, expected >0",
+                    "{} unexpected 'avalanche_avm_txs_accepted{{chain=\"X\",tx=\"base\"}}' {}, expected >0",
                     ep.as_str(),
-                    *cur.get("avalanche_X_vm_avalanche_base_txs_accepted")
-                        .unwrap(),
+                    *cur.get("avalanche_avm_txs_accepted").unwrap(),
                 ),
             ));
         }


### PR DESCRIPTION
The following fields were deprecated in AvalancheGo [v1.11.11](https://github.com/ava-labs/avalanchego/releases/tag/v1.11.11):
- `info.peers.observedSubnetUptimes`
- `platform.getCurrentValidators.connected`

This PR makes the `connected` field optional and removes the `observedSubnetUptimes` field.